### PR TITLE
Travis fix for nloptr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - gpg -a --export E084DAB9 | sudo apt-key add -
 - sudo rm -vf /etc/apt/sources.list.d/*riak*
 - sudo apt-get update
-- sudo apt-get -y install r-base r-base-dev python-tk
+- sudo apt-get -y install r-base r-base-dev python-tk libnlopt-dev
 - sudo R -e "install.packages('versions', repos = 'http://cran.us.r-project.org');
   library(versions); install.versions(c('lme4','lmerTest','lsmeans'),c('1.1-12','2.0-33','2.25'))"
 - sudo pip install pytest


### PR DESCRIPTION
Should deal with Travis bug issues when nloptr URL is down/moved, e.g. see https://github.com/ejolly/pymer4/issues/23 and https://github.com/jyypma/nloptr/issues/40