### PR TITLE
Lmer varcor patch, test python bump to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 langauge: python
-python: "3.6"
+python: "3.7"
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -7,10 +7,11 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
 install:
-- conda create -n testenv python=3.6 pip pytest
+- conda create -n testenv python=3.7 pip pytest
 - source activate testenv
 - conda install -c conda-forge r-base=3.6.1 r-lme4=1.1_21 r-lmertest=3.1_0 r-emmeans=1.3.5.1 rpy2=3.1.0 "cffi<1.13"
 - pip install -r requirements.txt
 - python setup.py install
+- conda list
 script:
 - py.test

--- a/pymer4/models/Lmer.py
+++ b/pymer4/models/Lmer.py
@@ -641,20 +641,24 @@ class Lmer(object):
         self.fitted = True
 
         # Random effect variances and correlations
+        varcor_NAs = ["NA", "N", robjects.NA_Character]
         df = base.data_frame(unsum.rx2("varcor"))
-        ran_vars = df.query("(var2 == 'NA') | (var2 == 'N')").drop("var2", axis=1)
+
+        ran_vars = df.query("var2 in @varcor_NAs").drop("var2", axis=1)
         ran_vars.index = ran_vars["grp"]
         ran_vars.drop("grp", axis=1, inplace=True)
         ran_vars.columns = ["Name", "Var", "Std"]
         ran_vars.index.name = None
         ran_vars.replace("NA", "", inplace=True)
+        ran_vars.replace(robjects.NA_Character, "", inplace=True)
 
-        ran_corrs = df.query("(var2 != 'NA') & (var2 != 'N')").drop("vcov", axis=1)
+        ran_corrs = df.query("var2 not in @varcor_NAs").drop("vcov", axis=1)
         if ran_corrs.shape[0] != 0:
             ran_corrs.index = ran_corrs["grp"]
             ran_corrs.drop("grp", axis=1, inplace=True)
             ran_corrs.columns = ["IV1", "IV2", "Corr"]
             ran_corrs.index.name = None
+            ran_corrs.replace(robjects.NA_Character, "", inplace=True)
         else:
             ran_corrs = None
 

--- a/pymer4/tests/test_models.py
+++ b/pymer4/tests/test_models.py
@@ -6,6 +6,8 @@ import numpy as np
 from scipy.special import logit
 from scipy.stats import ttest_ind
 import os
+import pytest
+import re
 
 np.random.seed(10)
 
@@ -284,3 +286,27 @@ def test_glmer_opt_passing():
         summarize=False, control="optCtrl = list(FtolAbs=1e-1, FtolRel=1e-1, maxfun=10)"
     )
     assert len(m.warnings) >= 1
+
+
+# all or prune to suit
+# tests_ = [eval(v) for v in locals() if re.match(r"^test_",  str(v))]
+tests_ = [
+    (test_gaussian_lm2),
+    (test_gaussian_lm),
+    (test_gaussian_lmm),
+    (test_post_hoc),
+    (test_logistic_lmm),
+    (test_anova),
+    (test_poisson_lmm),
+    (test_gamma_lmm),
+    (test_inverse_gaussian_lmm),
+    (test_lmer_opt_passing),
+    (test_glmer_opt_passing),
+]
+@pytest.mark.parametrize("model", tests_)
+def test_Pool(model):
+    from multiprocessing import Pool
+    # squeeze model functions through Pool pickling
+    print("Pool", model.__name__)
+    with Pool(1) as pool:
+        _ = pool.apply(model, [])

--- a/pymer4/tests/test_models.py
+++ b/pymer4/tests/test_models.py
@@ -291,22 +291,22 @@ def test_glmer_opt_passing():
 # all or prune to suit
 # tests_ = [eval(v) for v in locals() if re.match(r"^test_",  str(v))]
 tests_ = [
-    (test_gaussian_lm2),
-    (test_gaussian_lm),
-    (test_gaussian_lmm),
-    (test_post_hoc),
-    (test_logistic_lmm),
-    (test_anova),
-    (test_poisson_lmm),
-    (test_gamma_lmm),
-    (test_inverse_gaussian_lmm),
-    (test_lmer_opt_passing),
-    (test_glmer_opt_passing),
+    test_gaussian_lm2,
+    test_gaussian_lm,
+    test_gaussian_lmm,
+    test_post_hoc,
+    test_logistic_lmm,
+    test_anova,
+    test_poisson_lmm,
+    test_gamma_lmm,
+    test_inverse_gaussian_lmm,
+    test_lmer_opt_passing,
+    test_glmer_opt_passing,
 ]
 @pytest.mark.parametrize("model", tests_)
 def test_Pool(model):
-    from multiprocessing import Pool
+    from multiprocessing import get_context
     # squeeze model functions through Pool pickling
     print("Pool", model.__name__)
-    with Pool(1) as pool:
+    with get_context("spawn").Pool(1) as pool:
         _ = pool.apply(model, [])


### PR DESCRIPTION
Handles `robject.NA_character` in df = base.data_frame(unsum.rx2("varcor")) the same way as "NA" and "N" strings.

This fixes missing `Lmer.ranef_vars` and garbled `Lmer.ranef_corrs` in `Lmer.summary()` (see #57).  

Replacing the NA_character objects with "" as intended also allows functions wrapping Lmer models to pass through multiprocessing.Pool.

Added pytests for multiprocessing.Pool

Added `conda list` .travis.yml to report information on the origin and build of conda packages.

pytests also pass in Python 3.6.