### PR TITLE
fix: retain index of random effects

### DIFF
--- a/pymer4/models/Lmer.py
+++ b/pymer4/models/Lmer.py
@@ -796,16 +796,25 @@ class Lmer(object):
             colnames(df) <- make.unique(colnames(df))
             df
             }
+            getIndex <- function(df){
+            df <- transform(df, index=row.names(df))
+            df
+            }
             out <- lapply(ranef(model),uniquify)
+            out <- lapply(out, getIndex)
             out
             }
         """
         ranef_func = robjects.r(rstring)
         ranefs = ranef_func(self.model_obj)
         if len(ranefs) > 1:
-            self.ranef = [pd.DataFrame(e) for e in ranefs]
+            self.ranef = [
+                pd.DataFrame(e, index=e.index).drop(columns=["index"]) for e in ranefs
+            ]
         else:
-            self.ranef = pd.DataFrame(ranefs[0])
+            self.ranef = pd.DataFrame(ranefs[0], index=ranefs[0].index).drop(
+                columns=["index"]
+            )
 
         # Model residuals
         rstring = """

--- a/pymer4/tests/test_models.py
+++ b/pymer4/tests/test_models.py
@@ -111,6 +111,7 @@ def test_gaussian_lmm():
     assert isinstance(model.ranef, list)
     assert model.ranef[0].shape == (47, 2)
     assert model.ranef[1].shape == (3, 1)
+    assert (model.ranef[1].index == ['0.5', '1', '1.5']).all()
 
     assert model.ranef_corr.shape == (1, 3)
     assert model.ranef_var.shape == (4, 3)


### PR DESCRIPTION
Hi sir, 

I tried to use your package to retrieve the random effects using `model.ranef` to use random slope / random intercept estimates for further analyses. I noticed however that the index keys that can be used to connect the random estimates with other data were omitted during the conversion. 

I created a tiny pull request that resolves this issue and now passes the index keys back to `model.ranef`
Looking forward to your review. 
Thank you.